### PR TITLE
Rewrite XS code to fix bug

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -30,6 +30,9 @@ my @tests = (
      # disallow "," as a delimiter
     [ 'Foo=Bar; Bar=Baz,  XXX=Foo%20Bar   ; YYY=; ', { Foo => 'Bar', Bar => 'Baz,  XXX=Foo Bar',YYY=>"" }],
 
+    [ '%=";', {'%' => '"' }],
+    [ ';%=";', {'%' => '"' }],
+    [ ';;;;;      A="B"";;C=D', { A => 'B"', C => 'D' }],
 
     [ '', {} ],
     [ undef, {} ],


### PR DESCRIPTION
A review of the XS code in this module raised some questions, so we
rewrote it for clarity and fixed a bug.

 - Re-work to use memchr to find ; and DRY up the case where there's no ;.

 - Add some missing bounds checking on the main parsing, reworking to make
   the checks more obvious.
     - Fixes an issue where string starting with ';' causes a memory access
       before the start of the passed string.

 - Add length checks for '%##' decoding
     - Fixes potential accesses past the end of the key/value

 - Fix issue with quoted value handling
     - A value of a single quote would cause a negative value to be passed
       to svGROW().

Some performance analysis for a typical cookie:

 - pure-perl 111k/s
 - original XS 785k/s
 - this new XS 918k/s.